### PR TITLE
Kubernetes controllers

### DIFF
--- a/kubernetes-controllers/deployment.yaml
+++ b/kubernetes-controllers/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homework-deployment
+  namespace: homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: homework-pod
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: homework-pod
+    spec:
+      volumes:
+        - name: shared-volume
+          emptyDir: {}
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+      initContainers:
+        - name: init-container
+          image: busybox
+          command: ['sh', '-c', 'echo "<html><body><h1>Hello, World!</h1></body></html>" > /homework/index.html']
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /homework
+      containers:
+        - name: web-server
+          image: nginx
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /homework
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm /homework/index.html"]
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/homework/index.html"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      restartPolicy: Always
+      nodeSelector:
+        homework: "true"
+

--- a/kubernetes-controllers/namespace.yaml
+++ b/kubernetes-controllers/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework
+

--- a/kubernetes-controllers/nginx-config.yaml
+++ b/kubernetes-controllers/nginx-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: homework
+data:
+  default.conf: |
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            root /homework;
+            index index.html;
+        }
+    }
+

--- a/kubernetes-controllers/pod.yaml
+++ b/kubernetes-controllers/pod.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: homework-pod
+  namespace: homework
+  labels:
+    app: homework-pod
+spec:
+  volumes:
+    - name: shared-volume
+      emptyDir: {}
+  initContainers:
+    - name: init-container
+      image: busybox
+      command: ['sh', '-c', 'echo "<html><body><h1>Hello, World!</h1></body></html>" > /init/index.html']
+      volumeMounts:
+        - name: shared-volume
+          mountPath: /init
+  containers:
+    - name: web-server
+      image: nginx
+      ports:
+        - containerPort: 80
+      volumeMounts:
+        - name: shared-volume
+          mountPath: /homework
+      lifecycle:
+        preStop:
+          exec:
+            command: ["/bin/sh", "-c", "rm /homework/index.html"]
+  restartPolicy: Never
+

--- a/kubernetes-controllers/service.yaml
+++ b/kubernetes-controllers/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homework-service
+  namespace: homework
+spec:
+  selector:
+    app: homework-pod
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 80
+

--- a/kubernetes-intro/namespace.yaml
+++ b/kubernetes-intro/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework
+

--- a/kubernetes-intro/pod.yaml
+++ b/kubernetes-intro/pod.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: homework-pod
+  namespace: homework
+  labels:
+    app: homework-pod
+spec:
+  volumes:
+    - name: shared-volume
+      emptyDir: {}
+  initContainers:
+    - name: init-container
+      image: busybox
+      command: ['sh', '-c', 'echo "<html><body><h1>Hello, World!</h1></body></html>" > /init/index.html']
+      volumeMounts:
+        - name: shared-volume
+          mountPath: /init
+  containers:
+    - name: web-server
+      image: nginx
+      ports:
+        - containerPort: 80
+      volumeMounts:
+        - name: shared-volume
+          mountPath: /homework
+      lifecycle:
+        preStop:
+          exec:
+            command: ["/bin/sh", "-c", "rm /homework/index.html"]
+  restartPolicy: Never
+

--- a/kubernetes-intro/service.yaml
+++ b/kubernetes-intro/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homework-service
+  namespace: homework
+spec:
+  selector:
+    app: homework-pod
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 80
+


### PR DESCRIPTION
# Выполнено ДЗ 2 kubernetes-controllers

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
Создан манифест namespace.yaml для namespace с именем homework
Создан манифест deployment.yaml в котором:
● Создается в namespace homework
● Запускается 3 экземпляра пода, полностью аналогичных по спецификации прошлому ДЗ.
● Имеет readiness пробу, проверяющую наличие файла /homework/index.html
● Стратегия обновления RollingUpdate, настроена так, что в процессе обновления может быть недоступен максимум 1 под.

Задание с *
● К манифесту deployment-а добавлена спецификация, обеспечивая запуск подов деплоймента, только на нодах кластера, имеющих метку homework=true

Дополнительно:
В прошлом ДЗ выводилась стандартная страница Nginx, котя нужный файл создавался. В этом задании меняются настройки Nginx

## Как запустить проект:
Выполняются следующие команды:

> kubectl apply -f namespace.yaml
> kubectl apply -f deployment.yaml
> kubectl apply -f nginx-config.yaml

Но если выполнить команду "kubectl get all -n homework", то видно, что поды не запущены:

> NAME                                      READY   STATUS    RESTARTS   AGE
> pod/homework-deployment-dbbbb5475-fd6rv   0/1     Pending   0          17m
> pod/homework-deployment-dbbbb5475-h28kp   0/1     Pending   0          17m
> pod/homework-deployment-dbbbb5475-rqghn   0/1     Pending   0          17m
> NAME                       TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
> service/homework-service   ClusterIP   10.106.196.134   <none>        8000/TCP   10m
> NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
> deployment.apps/homework-deployment   0/3     3            0           17m
> NAME                                            DESIRED   CURRENT   READY   AGE
> replicaset.apps/homework-deployment-dbbbb5475   3         3         0       17m

Тогда и добавим метку homework=true

> kubectl get nodes
> kubectl label nodes <node-name> homework=true

После этого поды запускаются.

## Как проверить работоспособность:
Ваполнит команду:

> kubectl describe service homework-service -n homework

Или запустить сервис следующей еомандой:
kubect

> l port-forward -n homework service/homework-service 8000:8000

А после этого посмотреть страницу в браузере. (перейти по ссылке http://localhost:8000)

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
